### PR TITLE
Replace % with f-string

### DIFF
--- a/README.md
+++ b/README.md
@@ -1140,7 +1140,7 @@ corresponds to
 
 ```kotlin
 short_greetings = [
-    "Hello, %s!" % p.name
+    f"Hello, {p.name}"
     for p in people
     if len(p.name) < 10
 ]


### PR DESCRIPTION
f-strings have been around for a while now (since 3.6) and are generally recognized as a better way to write formatted strings in Python.