### PR TITLE
fix: val to var for mutable value

### DIFF
--- a/08-loops.md
+++ b/08-loops.md
@@ -60,7 +60,7 @@ for ((index, value) in names.withIndex()) {
 The `while` loop is similar to Python (but keep in mind that the condition must be an actual boolean expression, as there's no concept of truthy or falsy values).
 
 ```kotlin
-val x = 0
+var x = 0
 while (x < 10) {
     println(x)
     x++ // Same as x += 1


### PR DESCRIPTION
In the example the variable `x` is mutated with `x++` and should
therefore be a declared as a `var` as opposed to an imnmutable `val`.